### PR TITLE
Fix file path for neonmodem.toml in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,13 @@ The binary is called `neonmodem`. Feel free to move it to e.g. `/usr/local/bin`.
 Before launching *Neon Modem Overdrive* it requires initial setup of the 
 services (a.k.a. *systems*). Run `neonmodem connect --help` to find out more.
 
-Connecting a service will add it to the configuration TOML, usually under 
-`~/.config/neonmodem.toml`.
+Connecting a service will add it to the configuration TOML.
+
+### Linux/Unix
+`~/.config/neonmodem.toml`
+
+### MacOS
+`$HOME/Library/Application\ Support/neonmodem.toml`
 
 
 ### Systems


### PR DESCRIPTION
The file path for `neonmodem.toml` in the README was incorrect for non-Linux systems. This updates the README to include the correct path used on MacOS. It's probable that the config path on Windows is also different, probably somewhere like `%APPDATA%` but I do not have a Windows system on hand to test this.