### PR TITLE
Add support for defining custom URL browser in config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -39,10 +39,10 @@ type ThemeItemConfig struct {
 }
 
 type Config struct {
-	Debug bool
-	Log   string
-	Proxy string
-
+	Debug         bool
+	Log           string
+	Proxy         string
+	Browser       string
 	RenderShadows bool
 	RenderImages  bool
 
@@ -188,6 +188,7 @@ func SetDefaults(cacheDir string) {
 	viper.SetDefault("Debug", "false")
 	viper.SetDefault("Log", path.Join(cacheDir, "neonmodem.log"))
 	viper.SetDefault("Proxy", "")
+	viper.SetDefault("Browser", "")
 
 	viper.SetDefault("RenderShadows", "true")
 	viper.SetDefault("RenderImages", "true")

--- a/ui/windows/postshow/handlers.go
+++ b/ui/windows/postshow/handlers.go
@@ -2,6 +2,8 @@ package postshow
 
 import (
 	"errors"
+	"os"
+	"os/exec"
 	"strconv"
 	"time"
 
@@ -91,6 +93,28 @@ func handleOpen(mi interface{}) (bool, []tea.Cmd) {
 	var cmds []tea.Cmd
 
 	openURL := m.activePost.URL
+
+	browserPath := m.ctx.Config.Browser
+	if browserPath != "" {
+		if _, err := os.Stat(browserPath); err != nil {
+			m.ctx.Logger.Error(err)
+			cmds = append(cmds, cmd.New(
+				cmd.MsgError,
+				WIN_ID,
+				cmd.Arg{
+					Name:  "error",
+					Value: err,
+				},
+			).Tea())
+			return true, cmds
+		}
+		cmd := exec.Command(browserPath, openURL)
+		cmd.Stdout = os.Stdout
+		cmd.Stderr = os.Stderr
+		cmd.Run()
+		return true, cmds
+	}
+
 	browser.Stderr = nil
 	browser.Stdout = nil
 	if err := browser.OpenURL(openURL); err != nil {


### PR DESCRIPTION
`github.com/pkg/browser` is a great abstraction for opening file and web paths using the system default but it lacks the flexibility necessary to allow application developers to override the system default. On some systems, such as Linux, you can fudge this by wrapping `neonmodem` in a function that temporarily flips the default browser using `xdg-mime` but this is pretty crude and does not work cross platform.

This PR provides an additional config option to set the path to a custom executable path for `neonmodem` to use when opening URLs. This config option is then checked and an alternate code path is shimmed in before the call to `browser` in `ui/windows/postsshow/handlers.go`. The implementation of `cmd` used the same approached used by `browser.OpenURL()`.

I've made the assumption that `/path/to/browser postURL` will launch the `postURL` in the defined browser using the browsers default behavior. I did my best to test this and I can confirm that setting it to the path for my Firefox binary works but I have not tested it with other browsers.