### PR TITLE
Fix #16 (connecting to HN)

### DIFF
--- a/cmd/connect.go
+++ b/cmd/connect.go
@@ -34,6 +34,7 @@ func connectBase() *cobra.Command {
 		},
 		Run: func(cmd *cobra.Command, args []string) {
 			sysConfig = make(map[string]interface{})
+			sysConfig["proxy"] = ""
 			sys, err := system.New(sysType, &sysConfig, LOG)
 			if err != nil {
 				LOG.Panicln(err)


### PR DESCRIPTION
As outlined in #16, the current state of the code in HEAD can not successfully connect to hackernews. After some digging I discovered that the value of `sys.config["proxy"]` was `nil` causing the type assertion to a string to fail. I'm not sure that this is the _BEST_ way to fix this issue but to the best of my knowledge, there is nowhere that appends a proxy key to `sys.config{}` (most systems are setting `sys.config` to `*cfg` in `SetConfig()` which does not, at the time it is called, have any reference to the proxy field in the config file).

I think it would be better to add this, or something similar, to `SysConfig{}` so that it does not need to be explicitly included in each system `SetConfig()` method, but attempts to do so failed, again, due to my limited knowledge around interfaces, specifically `map[string]interface{}`.