### PR TITLE
Fix segfault when entering incorrect password

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -98,11 +98,12 @@ func loadSystems(c *ctx.Ctx) []error {
 			errs = append(errs, err)
 		} else {
 			c.Logger.Debugf("loaded %s system", sysCfg.Type)
+
+			c.AddSystem(&sys)
+			c.Logger.Debugf("setting system ID to %d", c.NumSystems()-1)
+			sys.SetID(c.NumSystems() - 1)
 		}
 
-		c.AddSystem(&sys)
-		c.Logger.Debugf("setting system ID to %d", c.NumSystems()-1)
-		sys.SetID(c.NumSystems() - 1)
 	}
 
 	return errs


### PR DESCRIPTION
When configuring an account with an incorrect password `system.New()` returns `nil` which causes a segmentation fault when accessing `sys`:
```
sys, err := system.New(...)
if err != nil {
    ...
} else {
    ...
}
c.AddSystem(&sys) <--------- SIGSEGV here
```
One option would be to `panic()` when `err != nil`, but this goes against the structure of the already existing code, which iterates over all configured systems, collects error messages from each of them (if any), and **later** (when returning from `loadSystems()`), prints all these errors before `panic()`'ing.

Thus, we want **not** to `panic()` here, but still we want the `nil` pointer not to be accessed. The solution is simple: just include the code that accesses the `sys` object in the `else` branch:
```
sys, err := system.New(...)
if err != nil {
    ...
} else {
    ...
    c.AddSystem(&sys)
}
```

Note that, as explained before, when entering a wrong password the binary **will still fail** (wich a `panic()`) but at least now each of the reassons why each system could not be initialized will be printed to the log file.