### PR TITLE
resolves mrusme/neonmodem#32 Filter for lemmy communities

### DIFF
--- a/system/lemmy/connect.go
+++ b/system/lemmy/connect.go
@@ -50,5 +50,7 @@ func (sys *System) Connect(sysURL string) error {
 	sys.config["url"] = sysURL
 	sys.config["credentials"] = credentials
 
+	sys.config["MaxSubscriptions"] = MaxSubscriptions
+
 	return nil
 }

--- a/system/lemmy/constant.go
+++ b/system/lemmy/constant.go
@@ -1,0 +1,4 @@
+package lemmy
+
+// Limit the maximum number of subscription queries
+const MaxSubscriptions = 10000

--- a/system/lemmy/lemmy.go
+++ b/system/lemmy/lemmy.go
@@ -6,7 +6,6 @@ import (
 	"net/http"
 	"net/url"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/mrusme/neonmodem/models/author"
@@ -157,24 +156,12 @@ func (sys *System) Load() error {
 }
 
 func communityFullname(community types.CommunitySafe) (communityName string) {
-	instanceName := ""
-	if community.ActorID != "" {
-	    removeUrlScheme := strings.NewReplacer(
-		"http://", "",
-		"https://", "",
-	    )
-	    instanceName = removeUrlScheme.Replace(
-		    community.ActorID)
-	    splitUrl := strings.Split(instanceName, "/")
-	    if len(splitUrl) > 1 {
-		instanceName = splitUrl[0]
-	    }
+	url, err := url.Parse(community.ActorID)
+	if err != nil {
+		return community.Name
+	} else {
+		return community.Name + "@" + url.Host
 	}
-	communityName = community.Name
-	if instanceName != "" {
-		communityName += "@" + instanceName
-	}
-	return communityName
 }
 
 func (sys *System) ListForums() ([]forum.Forum, error) {

--- a/system/lemmy/lemmy.go
+++ b/system/lemmy/lemmy.go
@@ -19,6 +19,7 @@ import (
 	"go.uber.org/zap"
 )
 
+
 type System struct {
 	ID     int
 	config map[string]interface{}
@@ -178,11 +179,19 @@ func communityFullname(community types.CommunitySafe) (communityName string) {
 
 func (sys *System) ListForums() ([]forum.Forum, error) {
 	var models []forum.Forum
-	for j := 1; j < 100; j++ {
+	var maxSubscriptions int
+	if sys.config["MaxSubscriptions"] != nil {
+		maxSubscriptions = sys.config["MaxSubscriptions"].(int)
+	} else {
+		maxSubscriptions = MaxSubscriptions
+	}
+	page := 1
+	queryLimit := 50
+	for page < maxSubscriptions {
 		resp, err := sys.client.Communities(context.Background(), types.ListCommunities{
 			Type:  types.NewOptional(types.ListingTypeSubscribed),
-			Page: types.NewOptional(int64(j)),
-			Limit: types.NewOptional(int64(50)),
+			Page: types.NewOptional(int64(page)),
+			Limit: types.NewOptional(int64(queryLimit)),
 		})
 		if err != nil {
 			break
@@ -200,6 +209,7 @@ func (sys *System) ListForums() ([]forum.Forum, error) {
 				SysIDX: sys.ID,
 			})
 		}
+		page += 1
 	}
 	return models, nil
 }

--- a/system/lemmy/lemmy.go
+++ b/system/lemmy/lemmy.go
@@ -211,22 +211,23 @@ func (sys *System) ListPosts(forumID string) ([]post.Post, error) {
 		showAll = true
 	}
 
-	resp := &types.GetPostsResponse{}
+	var getPosts types.GetPosts
 	if showAll {
-		resp, err = sys.client.Posts(context.Background(), types.GetPosts{
+		getPosts = types.GetPosts{
 			Type:  types.NewOptional(types.ListingTypeSubscribed),
 			Sort:  types.NewOptional(types.SortTypeNew),
 			Limit: types.NewOptional(int64(50)),
-		})
+		}
 	} else {
-		resp, err = sys.client.Posts(context.Background(), types.GetPosts{
+		getPosts = types.GetPosts{
 			Type:  types.NewOptional(types.ListingTypeSubscribed),
 			Sort:  types.NewOptional(types.SortTypeNew),
 			Limit: types.NewOptional(int64(50)),
 			CommunityID: types.NewOptional(communityID),
-		})
+		}
 	}
 
+	resp, err := sys.client.Posts(context.Background(), getPosts)
 	if err != nil {
 		return []post.Post{}, err
 	}


### PR DESCRIPTION
A possible fix for Lemmy community filtering. Tested with make + go1.19.0.

A limitation is that we currently only request 50 posts at a time, and so some communities will be empty. I tried naively upping the limit value but this seems to result in no results, so probably need to send multiple requests and I'm not very experienced with requests in go:
```
system/lemmy/lemmy.go
184:		Limit: types.NewOptional(int64(100)),  // This fails to retrieve any results.
```