### PR TITLE
Optionally hide splash and banner?

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -45,6 +45,8 @@ type Config struct {
 	Browser       string
 	RenderShadows bool
 	RenderImages  bool
+	RenderSplash  bool
+	RenderBanner  bool
 
 	Systems []SystemConfig
 
@@ -192,6 +194,8 @@ func SetDefaults(cacheDir string) {
 
 	viper.SetDefault("RenderShadows", "true")
 	viper.SetDefault("RenderImages", "true")
+	viper.SetDefault("RenderSplash", "true")
+	viper.SetDefault("RenderBanner", "true")
 
 	// --- Header ---
 	// Header Selector

--- a/ui/header/header.go
+++ b/ui/header/header.go
@@ -111,6 +111,10 @@ func (m Model) View() string {
 		spinner = m.spinner.View()
 	}
 
+	if !m.ctx.Config.RenderBanner{
+		banner = ""
+	}
+
 	row = lipgloss.JoinHorizontal(lipgloss.Bottom,
 		banner,
 		"   ",

--- a/ui/views/splash/splash.go
+++ b/ui/views/splash/splash.go
@@ -33,6 +33,9 @@ func NewModel(c *ctx.Ctx) Model {
 		ctx: c,
 		pix: nil,
 	}
+	if !m.ctx.Config.RenderSplash {
+		return m
+	}
 
 	m.splashscreen, err = m.ctx.EmbedFS.ReadFile("splashscreen.png")
 	if err != nil {
@@ -74,7 +77,9 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 
 func (m *Model) sleep() tea.Cmd {
 	return func() tea.Msg {
-		time.Sleep(time.Second * 5)
+		if m.ctx.Config.RenderSplash {
+			time.Sleep(time.Second * 5)
+		}
 
 		c := cmd.New(
 			cmd.ViewOpen,


### PR DESCRIPTION
I thought it might be nice to make the startup screen and logo optional for optimum linux ricing, and making it easier to jump in and out of the GUI while procrastinating between terminal commands. I can understand if this might be undesirable so submitting the PR speculatively, and feel free to decline if you think this harms the project.

Tested with the config options:
```
RenderSplash = false
RenderBanner = false
```