### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,9 @@ make
 
 The binary is called `neonmodem`. Feel free to move it to e.g. `/usr/local/bin`.
 
+For Arch Linux an AUR package is available here: https://aur.archlinux.org/packages/neonmodem
+
+Install with your favorite AUR helper.
 
 ## Configuration
 


### PR DESCRIPTION
Hey,

not sure if you already knew it, but neonmodem is available in the AUR and though installable via any AUR helper for Arch based distros.


