### PR TITLE
discourse: APi fixes

### DIFF
--- a/system/discourse/api/posts.go
+++ b/system/discourse/api/posts.go
@@ -69,7 +69,7 @@ type PostModel struct {
 	EditReason                  string `json:"edit_reason"`
 	CanViewEditHistory          bool   `json:"can_view_edit_history"`
 	Wiki                        bool   `json:"wiki"`
-	ReviewableID                string `json:"reviewable_id"`
+	ReviewableID                int    `json:"reviewable_id"`
 	ReviewableScoreCount        int    `json:"reviewable_score_count"`
 	ReviewableScorePendingCount int    `json:"reviewable_score_pending_count"`
 }

--- a/system/discourse/api/topics.go
+++ b/system/discourse/api/topics.go
@@ -74,7 +74,7 @@ type TopicModel struct {
 		Extras         string `json:"extras"`
 		Description    string `json:"description"`
 		UserID         int    `json:"user_id"`
-		PrimaryGroupID string `json:"primary_group_id"`
+		PrimaryGroupID int    `json:"primary_group_id"`
 	} `json:"posters"`
 }
 


### PR DESCRIPTION
it seems that the discourse APi changed the two fields `PostModel.post_stream.posts.reviewable_id` and
`.topic_list.topics.posters.primary_group_id` from string to integer.

change this accordingly to fix listing and viewing discourse posts in neonmodem.

closes #68